### PR TITLE
51 restrict external access to thunder idp

### DIFF
--- a/services/docker-compose.yaml
+++ b/services/docker-compose.yaml
@@ -77,7 +77,7 @@ services:
     image: ghcr.io/asgardeo/thunder:latest
     container_name: thunder-server
     ports:
-      - "8090:8090"
+      - "127.0.0.1:8090:8090"
     networks:
       - mail-network
     volumes:

--- a/services/init.sh
+++ b/services/init.sh
@@ -134,6 +134,21 @@ echo "password = \"\$2\$8hn4c88rmafsueo4h3yckiirwkieidb3\$uge4i3ynbba89qpo1gqmqk
 echo -e "${GREEN}✓ worker-controller.inc created for spam filter${NC}"
 
 # ================================
+# Step 4.5: Ensure ${MAIL_DOMAIN} points to 127.0.0.1 in /etc/hosts
+# ================================
+echo -e "\n${YELLOW}Step 4.5: Updating ${MAIL_DOMAIN} mapping in /etc/hosts${NC}"
+
+if grep -q "[[:space:]]${MAIL_DOMAIN}" /etc/hosts; then
+    # Replace existing entry
+    sudo sed -i "s/^.*[[:space:]]${MAIL_DOMAIN}/127.0.0.1   ${MAIL_DOMAIN}/" /etc/hosts
+    echo -e "${GREEN}✓ Updated existing ${MAIL_DOMAIN} entry to 127.0.0.1${NC}"
+else
+    # Add new if not present
+    echo "127.0.0.1   ${MAIL_DOMAIN}" | sudo tee -a /etc/hosts > /dev/null
+    echo -e "${GREEN}✓ Added ${MAIL_DOMAIN} entry to /etc/hosts${NC}"
+fi
+
+# ================================
 # Step 5: Thunder TLS Configuration
 # ================================
 echo -e "\n${YELLOW}Step 5/7: Configuring Thunder TLS certificates${NC}"


### PR DESCRIPTION
This pull request improves the security and reliability of the local mail server setup by restricting network access to the Thunder service and ensuring proper hostname resolution for the mail domain. The most important changes are:

**Network Security Improvements:**

* In `services/docker-compose.yaml`, the Thunder service port mapping is changed to bind only to `127.0.0.1`, preventing external access to port 8090.

**Hostname Resolution Setup:**

* In `services/init.sh`, a new step is added to ensure `${MAIL_DOMAIN}` is mapped to `127.0.0.1` in `/etc/hosts`, updating or adding the entry as needed for reliable local resolution.