### PR TITLE
fix: update authentication endpoint and ommit the token retrieval

### DIFF
--- a/services/silver-config/static/dovecot/auth_api.lua
+++ b/services/silver-config/static/dovecot/auth_api.lua
@@ -9,12 +9,13 @@ local function api_authenticate(user, password, req)
 
     local request_body = json.encode({
         email = user,
-        password = password
+        password = password,
+        skip_assertion = true
     })
     local response_body = {}
 
     local params = {
-        url = "https://thunder-server:8090/users/authenticate",
+        url = "https://thunder-server:8090/auth/credentials/authenticate",
         method = "POST",
         headers = {
             ["Content-Type"] = "application/json",


### PR DESCRIPTION
## 📌 Description
This PR is to update the Authentication endpoint in Dovecot to authenticate the users. Thunder has changed the API endpoint in v0.10.0.

- Closes #127 

---

## 🔍 Changes Made
1. Update the authentication API endpoint name.
2. Omit the token given by Thunder.
- 

---

## ✅ Checklist (Email System)
- [x] Core services tested (SMTP, IMAP, mail storage, end-to-end delivery)
- [x] Security & compliance verified (auth via Thunder IDP, TLS, DKIM/SPF/DMARC, spam/virus filtering)
- [x] Configuration & deployment checked (configs generated, Docker/Compose updated)
- [x] Reliability confirmed (error handling, logging, monitoring)
- [x] Documentation & usage notes updated (README, deployment, API)

---

## 🧪 Testing Instructions
<!-- Explain how reviewers can test your changes. -->

---

## 📷 Screenshots / Logs (if applicable)
<!-- Add screenshots of client tests, log snippets, etc. -->

---

## ⚠️ Notes for Reviewers
<!-- Add special notes for reviewers (e.g., schema changes, ports affected, config updates). -->