### PR TITLE
216 bug disable push into the ghcr from forks main

### DIFF
--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   detect-changes:
     runs-on: ubuntu-latest
+    if: github.repository == 'lsflk/silver'
     outputs:
       smtp: ${{ steps.changes.outputs.smtp }}
       imap: ${{ steps.changes.outputs.imap }}


### PR DESCRIPTION
## 📌 Description
This PR is to desable push the build images into lsflk/silver repo GHCR when you merge into the fork's main branch.

- Closes #216 

---

## 🔍 Changes Made
<!-- List key changes in bullet points. -->
- Add if condition to check before running the workflow

---

## ✅ Checklist (Email System)
- [x] Core services tested (SMTP, IMAP, mail storage, end-to-end delivery)
- [x] Security & compliance verified (auth via Thunder IDP, TLS, DKIM/SPF/DMARC, spam/virus filtering)
- [x] Configuration & deployment checked (configs generated, Docker/Compose updated)
- [x] Reliability confirmed (error handling, logging, monitoring)
- [x] Documentation & usage notes updated (README, deployment, API)

---

## 🧪 Testing Instructions
<!-- Explain how reviewers can test your changes. -->

---

## 📷 Screenshots / Logs (if applicable)
<!-- Add screenshots of client tests, log snippets, etc. -->

---

## ⚠️ Notes for Reviewers
<!-- Add special notes for reviewers (e.g., schema changes, ports affected, config updates). -->