### PR TITLE
239 bug review and secure public vs private ports disable unnecessary metrics endpoints

### DIFF
--- a/services/docker-compose.seaweedfs.yaml
+++ b/services/docker-compose.seaweedfs.yaml
@@ -2,9 +2,7 @@ services:
   master:
     image: chrislusf/seaweedfs:latest
     container_name: seaweedfs-master
-    ports:
-      - "9333:9333"
-      - "19333:19333"
+    # Ports removed - internal communication only via seaweedfs-net
     command: "master -ip=master -ip.bind=0.0.0.0 -port=9333"
     networks:
       - seaweedfs-net
@@ -18,9 +16,7 @@ services:
   volume:
     image: chrislusf/seaweedfs:latest
     container_name: seaweedfs-volume
-    ports:
-      - "8081:8080"
-      - "18081:18080"
+    # Ports removed - internal communication only via seaweedfs-net
     command: 'volume -mserver="master:9333" -ip.bind=0.0.0.0 -port=8080 -max=10'
     depends_on:
       master:
@@ -39,9 +35,7 @@ services:
   filer:
     image: chrislusf/seaweedfs:latest
     container_name: seaweedfs-filer
-    ports:
-      - "8888:8888"
-      - "18888:18888"
+    # Ports removed - internal communication only via seaweedfs-net
     command: 'filer -master="master:9333" -ip.bind=0.0.0.0'
     depends_on:
       master:
@@ -73,6 +67,7 @@ services:
     volumes:
       - ./seaweedfs/s3-config.json:/etc/seaweedfs/s3.json:ro
     restart: unless-stopped
+
 networks:
   seaweedfs-net:
     driver: bridge


### PR DESCRIPTION
## 📌 Description
This PR is to secure public ports and disable unnecessary ports.
<!-- Provide a clear, concise description of what this PR does. -->

- Closes #239 

---

## 🔍 Changes Made
<!-- List key changes in bullet points. -->
- Remove all unnecessary public ports in SeaweedFS

---

## ✅ Checklist (Email System)
- [x] Core services tested (SMTP, IMAP, mail storage, end-to-end delivery)
- [x] Security & compliance verified (auth via Thunder IDP, TLS, DKIM/SPF/DMARC, spam/virus filtering)
- [x] Configuration & deployment checked (configs generated, Docker/Compose updated)
- [x] Reliability confirmed (error handling, logging, monitoring)
- [x] Documentation & usage notes updated (README, deployment, API)

---

## 🧪 Testing Instructions
<!-- Explain how reviewers can test your changes. -->
---

## 📷 Screenshots / Logs (if applicable)
<!-- Add screenshots of client tests, log snippets, etc. -->

---

## ⚠️ Notes for Reviewers
<!-- Add special notes for reviewers (e.g., schema changes, ports affected, config updates). -->