### PR TITLE
285 feature create service to expose essential metadata for super platform

### DIFF
--- a/services/.env.example
+++ b/services/.env.example
@@ -10,3 +10,21 @@ GRAFANA_ADMIN_PASSWORD=
 
 # Please use single quotes for the webhook URL to avoid issues with special characters
 GOOGLE_CHAT_WEBHOOK_URL=''
+
+# Metadata Service Environment Configuration
+
+# ClamAV Database Path (should match volume mount)
+CLAMAV_DB_PATH=/var/lib/clamav
+
+# External API URL (Super Platform endpoint to push metadata to)
+# Example: https://super-platform.example.com/api/metadata/receive
+EXTERNAL_API_URL=
+
+# Push interval in seconds (how often to send metadata to external API)
+PUSH_INTERVAL_SECONDS=60
+
+# Enable/disable periodic push service (true/false)
+ENABLE_PUSH_SERVICE=true
+
+# API Key for authenticating with the external API (should be kept secret in production)
+API_KEY=

--- a/services/docker-compose.yaml
+++ b/services/docker-compose.yaml
@@ -187,6 +187,29 @@ services:
     networks:
       - mail-network
 
+  metadata-service:
+    build:
+      context: ./metadata-service
+      dockerfile: Dockerfile
+    container_name: metadata-service
+    ports:
+      - "8888:8888"
+    volumes:
+      - clamav_db:/var/lib/clamav:ro
+    environment:
+      - PORT=8888
+      - CLAMAV_DB_PATH=/var/lib/clamav
+      - EXTERNAL_API_URL=${EXTERNAL_API_URL}
+      - PUSH_INTERVAL_SECONDS=${PUSH_INTERVAL_SECONDS:-60}
+      - ENABLE_PUSH_SERVICE=${ENABLE_PUSH_SERVICE:-true}
+      - API_KEY=${API_KEY}
+    networks:
+      - mail-network
+      - observability
+    restart: unless-stopped
+    depends_on:
+      - clamav-server
+
   postfix-exporter:
     image: chatwork/kumina-postfix-exporter:latest
     container_name: postfix-exporter

--- a/services/metadata-service/.dockerignore
+++ b/services/metadata-service/.dockerignore
@@ -1,0 +1,26 @@
+# Go specific
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+*.test
+*.out
+vendor/
+
+# IDE
+.vscode/
+.idea/
+
+# Documentation (don't include in build)
+README.md
+
+# Git
+.git
+.gitignore
+
+# Environment
+.env
+
+# OS
+.DS_Store

--- a/services/metadata-service/Dockerfile
+++ b/services/metadata-service/Dockerfile
@@ -1,0 +1,41 @@
+# Build stage
+FROM golang:1.21-alpine AS builder
+
+WORKDIR /app
+
+# Install build dependencies
+RUN apk add --no-cache git
+
+# Copy go mod files
+COPY go.mod go.sum ./
+
+# Download dependencies
+RUN go mod download
+
+# Copy source code
+COPY main.go ./
+
+# Build the binary
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o metadata-service .
+
+# Runtime stage
+FROM alpine:latest
+
+RUN apk --no-cache add ca-certificates
+
+# Create a non-root user and group
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+WORKDIR /app
+
+# Copy the binary from builder and set ownership
+COPY --from=builder --chown=appuser:appgroup /app/metadata-service .
+
+# Switch to non-root user
+USER appuser
+
+# Expose metadata API port
+EXPOSE 8888
+
+# Run the service
+CMD ["./metadata-service"]

--- a/services/metadata-service/Makefile
+++ b/services/metadata-service/Makefile
@@ -1,0 +1,16 @@
+.PHONY: build run clean docker-build
+
+BINARY_NAME=metadata-service
+DOCKER_IMAGE=silver-metadata-service
+
+build:
+	go build -o $(BINARY_NAME) main.go
+
+run:
+	go run main.go
+
+clean:
+	rm -f $(BINARY_NAME)
+
+docker-build:
+	docker build -t $(DOCKER_IMAGE) .

--- a/services/metadata-service/README.md
+++ b/services/metadata-service/README.md
@@ -1,0 +1,151 @@
+# Silver Metadata Service
+
+A Go service that sends ClamAV signature heartbeat data to the Super Platform.
+
+## What It Does
+
+- Monitors ClamAV signature database (`daily.cvd/cld`)
+- Automatically detects server IP address
+- Sends heartbeat data every 60 seconds (configurable)
+- Receives results from Super Platform
+
+## Quick Start
+
+### 1. Configure
+
+Edit `.env` file:
+```bash
+EXTERNAL_API_URL=https://your-super-platform.com/v1/silver/events
+API_KEY=your-secret-api-key-here
+PUSH_INTERVAL_SECONDS=60
+```
+
+### 2. Deploy
+
+```bash
+docker-compose up -d metadata-service
+```
+
+### 3. Check Logs
+
+```bash
+docker-compose logs -f metadata-service
+```
+
+You should see:
+```
+Instance ID: 192.168.1.100
+Sending heartbeat: {"timestamp":"2026-03-05T10:30:00Z","instance_id":"192.168.1.100"...}
+Successfully pushed heartbeat to Super Platform (status: 200)
+```
+
+## Heartbeat Payload
+
+The service sends this JSON every 60 seconds:
+
+```json
+{
+  "timestamp": "2026-03-05T10:31:00Z",
+  "instance_id": "192.168.1.100",
+  "signature_version": "daily.cvd:27930",
+  "signature_updated_at": "2026-03-04T08:55:00Z"
+}
+```
+
+**Fields:**
+- `timestamp` - Current time (UTC)
+- `instance_id` - Server IP address (auto-detected)
+- `signature_version` - ClamAV database version
+- `signature_updated_at` - When signature was last updated
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `EXTERNAL_API_URL` | Yes | - | Super Platform endpoint URL |
+| `API_KEY` | Yes* | - | API key for authentication |
+| `PUSH_INTERVAL_SECONDS` | No | 60 | Heartbeat frequency |
+| `ENABLE_PUSH_SERVICE` | No | true | Enable/disable heartbeat |
+| `PORT` | No | 8888 | Service port |
+| `CLAMAV_DB_PATH` | No | /var/lib/clamav | ClamAV database location |
+
+*Required for receiving results from Super Platform
+
+## API Endpoints
+
+### GET /health
+
+Health check (no authentication required)
+
+```bash
+curl http://localhost:8888/health
+```
+
+Response:
+```json
+{
+  "status": "healthy",
+  "timestamp": "2026-03-05T10:30:00Z"
+}
+```
+
+### POST /api/results
+
+Receive results from Super Platform (requires API key)
+
+```bash
+curl -X POST http://localhost:8888/api/results \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: your-secret-api-key-here" \
+  -d '{
+    "status": "success",
+    "timestamp": "2026-03-05T10:30:00Z",
+    "data": {}
+  }'
+```
+
+## Build & Run
+
+### Using Docker
+```bash
+docker-compose up -d metadata-service
+```
+
+### Using Makefile
+```bash
+make build    # Build binary
+make run      # Run locally
+make clean    # Clean up
+```
+
+### Manual Build
+```bash
+go build -o metadata-service main.go
+./metadata-service
+```
+
+## Troubleshooting
+
+**No heartbeats being sent?**
+1. Check `EXTERNAL_API_URL` is set correctly
+2. Verify `ENABLE_PUSH_SERVICE=true`
+3. Check logs: `docker-compose logs metadata-service`
+
+**Instance ID showing "unknown"?**
+- Network connectivity issue
+- Check logs for "Warning: could not determine server IP"
+
+**ClamAV signature version is 0?**
+1. Verify `/var/lib/clamav/daily.cvd` exists
+2. Check ClamAV container is running
+3. Wait for ClamAV to download signatures
+
+**Authentication errors?**
+- Verify `API_KEY` matches between client and server
+- Include `X-API-Key` header in requests
+
+## More Information
+
+- [API Authentication Guide](./API_AUTHENTICATION.md)
+- [Super Platform Integration](./SUPER_PLATFORM_INTEGRATION.md)
+- [Instance ID Changes](./INSTANCE_ID_CHANGE.md)

--- a/services/metadata-service/go.mod
+++ b/services/metadata-service/go.mod
@@ -1,0 +1,5 @@
+module github.com/lsflk/silver-metadata-service
+
+go 1.21
+
+require github.com/gorilla/mux v1.8.1

--- a/services/metadata-service/go.sum
+++ b/services/metadata-service/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=

--- a/services/metadata-service/main.go
+++ b/services/metadata-service/main.go
@@ -1,0 +1,369 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+// HTTP client with timeout
+var httpClient = &http.Client{
+	Timeout: 15 * time.Second,
+}
+
+// Compiled regex for ClamAV CVD header parsing
+var clamAVVDBRegex = regexp.MustCompile(`ClamAV-VDB:(\d+):(\d+):`)
+
+// sanitizeForLog removes newline and carriage return characters to prevent log injection
+func sanitizeForLog(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	return s
+}
+
+// Configuration
+type Config struct {
+	Port              string
+	ClamAVDBPath      string
+	ExternalAPIURL    string
+	PushInterval      time.Duration
+	EnablePushService bool
+	APIKey            string
+	InstanceID        string
+}
+
+// SuperPlatformHeartbeat represents the heartbeat payload for Super Platform
+type SuperPlatformHeartbeat struct {
+	Timestamp           string `json:"timestamp"`
+	InstanceID          string `json:"instance_id"`
+	SignatureVersion    string `json:"signature_version"`
+	SignatureUpdatedAt  string `json:"signature_updated_at"`
+}
+
+// SuperPlatformResult represents data received from Super Platform
+type SuperPlatformResult struct {
+	Status    string                 `json:"status"`
+	Data      map[string]interface{} `json:"data"`
+	Timestamp string                 `json:"timestamp"`
+}
+
+var config Config
+
+func init() {
+	config = Config{
+		Port:              getEnv("PORT", "8888"),
+		ClamAVDBPath:      getEnv("CLAMAV_DB_PATH", "/var/lib/clamav"),
+		ExternalAPIURL:    getEnv("EXTERNAL_API_URL", ""),
+		PushInterval:      time.Duration(getEnvAsInt("PUSH_INTERVAL_SECONDS", 60)) * time.Second,
+		EnablePushService: getEnv("ENABLE_PUSH_SERVICE", "true") == "true",
+		APIKey:            getEnv("API_KEY", ""),
+		InstanceID:        getServerIP(), // Use server IP as instance ID
+	}
+}
+
+func getEnv(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}
+
+func getEnvAsInt(key string, defaultValue int) int {
+	if value := os.Getenv(key); value != "" {
+		if intVal, err := strconv.Atoi(value); err == nil {
+			return intVal
+		}
+		log.Printf("Warning: could not parse env var %s=%s as integer. Using default.", key, value)
+	}
+	return defaultValue
+}
+
+// getServerIP attempts to get the server's outbound IP address
+func getServerIP() string {
+	// Try to get the outbound IP by connecting to a public DNS server
+	conn, err := net.Dial("udp", "8.8.8.8:80")
+	if err != nil {
+		log.Printf("Warning: could not determine server IP: %v", err)
+		return "unknown"
+	}
+	defer conn.Close()
+
+	localAddr := conn.LocalAddr().(*net.UDPAddr)
+	return localAddr.IP.String()
+}
+
+// getClamAVSignatureInfo reads ClamAV daily.cvd file information
+func getClamAVSignatureInfo() (version int, updatedAt time.Time, err error) {
+	// Look for daily.cvd or daily.cld
+	dailyPath := filepath.Join(config.ClamAVDBPath, "daily.cvd")
+	
+	// Check if daily.cvd exists, otherwise try daily.cld
+	info, err := os.Stat(dailyPath)
+	if os.IsNotExist(err) {
+		dailyPath = filepath.Join(config.ClamAVDBPath, "daily.cld")
+		info, err = os.Stat(dailyPath)
+		if err != nil {
+			return 0, time.Time{}, fmt.Errorf("daily.cvd/cld not found: %w", err)
+		}
+	}
+	
+	// Get modification time
+	updatedAt = info.ModTime()
+	
+	// Try to read CVD header to get version
+	file, err := os.Open(dailyPath)
+	if err != nil {
+		return 0, updatedAt, fmt.Errorf("failed to open %s: %w", dailyPath, err)
+	}
+	defer file.Close()
+	
+	header := make([]byte, 512)
+	if n, err := file.Read(header); err == nil && n > 0 {
+		// CVD header format: ClamAV-VDB:build_time:version:...
+		matches := clamAVVDBRegex.FindSubmatch(header[:100])
+		if len(matches) == 3 {
+			var ver int
+			if _, err := fmt.Sscanf(string(matches[2]), "%d", &ver); err == nil {
+				version = ver
+			}
+		}
+	}
+	
+	return version, updatedAt, nil
+}
+
+// createHeartbeatPayload creates the Super Platform heartbeat payload
+func createHeartbeatPayload() (*SuperPlatformHeartbeat, error) {
+	version, updatedAt, err := getClamAVSignatureInfo()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ClamAV signature info: %w", err)
+	}
+	
+	// Determine file name (daily.cvd or daily.cld)
+	fileName := "daily.cvd"
+	if _, err := os.Stat(filepath.Join(config.ClamAVDBPath, "daily.cvd")); os.IsNotExist(err) {
+		fileName = "daily.cld"
+	}
+	
+	return &SuperPlatformHeartbeat{
+		Timestamp:          time.Now().UTC().Format(time.RFC3339),
+		InstanceID:         config.InstanceID,
+		SignatureVersion:   fmt.Sprintf("%s:%d", fileName, version),
+		SignatureUpdatedAt: updatedAt.UTC().Format(time.RFC3339),
+	}, nil
+}
+
+// pushMetadataToExternalAPI sends heartbeat to Super Platform
+func pushMetadataToExternalAPI() error {
+	if config.ExternalAPIURL == "" {
+		return fmt.Errorf("EXTERNAL_API_URL not configured")
+	}
+
+	heartbeat, err := createHeartbeatPayload()
+	if err != nil {
+		return fmt.Errorf("failed to create heartbeat payload: %w", err)
+	}
+
+	jsonData, err := json.Marshal(heartbeat)
+	if err != nil {
+		return fmt.Errorf("failed to marshal heartbeat: %w", err)
+	}
+
+	log.Printf("Sending heartbeat: %s", string(jsonData))
+
+	resp, err := httpClient.Post(config.ExternalAPIURL, "application/json", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to send heartbeat: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("external API returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	log.Printf("Successfully pushed heartbeat to Super Platform (status: %d)", resp.StatusCode)
+	return nil
+}
+
+// startPeriodicPush starts the periodic metadata push service
+func startPeriodicPush() {
+	if !config.EnablePushService {
+		log.Println("Periodic push service is disabled")
+		return
+	}
+
+	if config.ExternalAPIURL == "" {
+		log.Println("Warning: EXTERNAL_API_URL not set. Periodic push service will not function.")
+		return
+	}
+
+	ticker := time.NewTicker(config.PushInterval)
+	go func() {
+		log.Printf("Starting periodic metadata push service (interval: %v)", config.PushInterval)
+		
+		// Push immediately on startup
+		if err := pushMetadataToExternalAPI(); err != nil {
+			log.Printf("Error pushing metadata on startup: %v", err)
+		}
+
+		// Then push periodically
+		for range ticker.C {
+			if err := pushMetadataToExternalAPI(); err != nil {
+				log.Printf("Error pushing metadata: %v", err)
+			}
+		}
+	}()
+}
+
+// HTTP Handlers
+
+func healthHandler(w http.ResponseWriter, r *http.Request) {
+	response := map[string]string{
+		"status":    "healthy",
+		"timestamp": time.Now().UTC().Format(time.RFC3339),
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}
+
+// apiKeyAuthMiddleware validates the API key for protected endpoints
+func apiKeyAuthMiddleware(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if config.APIKey == "" {
+			log.Println("Warning: API_KEY not configured, skipping authentication")
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		apiKey := r.Header.Get("X-API-Key")
+		if apiKey == "" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode(map[string]string{
+				"error": "Missing API key",
+			})
+			log.Printf("Unauthorized request to %s: missing API key", r.URL.Path)
+			return
+		}
+
+		if apiKey != config.APIKey {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode(map[string]string{
+				"error": "Invalid API key",
+			})
+			log.Printf("Unauthorized request to %s: invalid API key", r.URL.Path)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	}
+}
+
+// receiveSuperPlatformResultHandler handles incoming results from Super Platform
+func receiveSuperPlatformResultHandler(w http.ResponseWriter, r *http.Request) {
+	var result SuperPlatformResult
+	if err := json.NewDecoder(r.Body).Decode(&result); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": "Invalid JSON payload",
+		})
+		return
+	}
+
+	// TODO: Process the result from Super Platform
+	// For now, just log and acknowledge
+	log.Printf("Received result from Super Platform: status=%s, timestamp=%s", sanitizeForLog(result.Status), sanitizeForLog(result.Timestamp))
+	
+	// Sanitize data for logging by converting to JSON string
+	dataJSON, err := json.Marshal(result.Data)
+	if err == nil {
+		log.Printf("Data received: %s", sanitizeForLog(string(dataJSON)))
+	} else {
+		log.Printf("Data received: (unable to marshal)")
+	}
+
+	// Send acknowledgment
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"success":   true,
+		"message":   "Result received and queued for processing",
+		"timestamp": time.Now().UTC().Format(time.RFC3339),
+	})
+}
+
+// CORS Middleware
+func corsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-API-Key")
+
+		if r.Method == "OPTIONS" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// Logging Middleware
+func loggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		next.ServeHTTP(w, r)
+		log.Printf("%s %s %s", r.Method, r.RequestURI, time.Since(start))
+	})
+}
+
+func main() {
+	log.Println("Silver Metadata Service (Go)")
+	log.Printf("Port: %s", config.Port)
+	log.Printf("ClamAV DB Path: %s", config.ClamAVDBPath)
+	log.Printf("External API URL: %s", config.ExternalAPIURL)
+	log.Printf("Instance ID: %s", config.InstanceID)
+	log.Printf("Push Interval: %v", config.PushInterval)
+	log.Printf("Push Service Enabled: %v", config.EnablePushService)
+	
+	if config.APIKey != "" {
+		log.Println("API Key authentication enabled")
+	} else {
+		log.Println("Warning: API Key authentication not configured")
+	}
+
+	// Start periodic push service
+	startPeriodicPush()
+
+	// Setup router
+	router := mux.NewRouter()
+
+	// Routes
+	router.HandleFunc("/health", healthHandler).Methods("GET")
+	router.HandleFunc("/api/results", apiKeyAuthMiddleware(receiveSuperPlatformResultHandler)).Methods("POST")
+
+	// Apply middleware
+	handler := corsMiddleware(loggingMiddleware(router))
+
+	// Start server
+	addr := "0.0.0.0:" + config.Port
+	log.Printf("Server listening on %s", addr)
+	if err := http.ListenAndServe(addr, handler); err != nil {
+		log.Fatalf("Server failed to start: %v", err)
+	}
+}


### PR DESCRIPTION
## 📌 Description
Create seperate service to run periodically to expose the metadata of the silver instances to the super platform and act based on the super-platform responses.

- Closes #285 

---

## 🔍 Changes Made
<!-- List key changes in bullet points. -->
- Periodic Push Service: Automatically sends metadata to Super Platform every 1 minute (configurable)
- Result Reception: Receives processing results from Super Platform (`/api/results`)
- Health Check: Service health monitoring

---

## ✅ Checklist (Email System)
- [x] Core services tested (SMTP, IMAP, mail storage, end-to-end delivery)
- [x] Security & compliance verified (auth via Thunder IDP, TLS, DKIM/SPF/DMARC, spam/virus filtering)
- [x] Configuration & deployment checked (configs generated, Docker/Compose updated)
- [x] Reliability confirmed (error handling, logging, monitoring)
- [x] Documentation & usage notes updated (README, deployment, API)

---

## 🧪 Testing Instructions
<!-- Explain how reviewers can test your changes. -->
---

## 📷 Screenshots / Logs (if applicable)
<!-- Add screenshots of client tests, log snippets, etc. -->

---

## ⚠️ Notes for Reviewers
<!-- Add special notes for reviewers (e.g., schema changes, ports affected, config updates). -->
Need to discuss what the format of the request is that needs to be sent to the super platform, and what the response that the silver instance accepts. 