### PR TITLE
feat: add build step for metadata service in GitHub Actions and update Docker Compose configuration

### DIFF
--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -19,6 +19,7 @@ jobs:
       imap: ${{ steps.changes.outputs.imap }}
       dkim: ${{ steps.changes.outputs.dkim }}
       certbot: ${{ steps.changes.outputs.certbot }}
+      metadata: ${{ steps.changes.outputs.metadata }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -38,6 +39,8 @@ jobs:
               - 'services/dkim/**'
             certbot:
               - 'services/certbot/**'
+            metadata:
+              - 'services/metadata-service/**'
 
   build-smtp:
     needs: detect-changes
@@ -159,6 +162,48 @@ jobs:
         with:
           context: services/certbot
           file: services/certbot/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-metadata:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.metadata == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-metadata-service
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: services/metadata-service
+          file: services/metadata-service/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/services/docker-compose.yaml
+++ b/services/docker-compose.yaml
@@ -188,9 +188,7 @@ services:
       - mail-network
 
   metadata-service:
-    build:
-      context: ./metadata-service
-      dockerfile: Dockerfile
+    image: ghcr.io/lsflk/silver-metadata-service:main
     container_name: metadata-service
     ports:
       - "8888:8888"


### PR DESCRIPTION
## 📌 Description
<!-- Provide a clear, concise description of what this PR does. -->
This PR is to create docker image and push it into the GHCR and use it when the docker compose file is running to reduce the build time.

- Closes #287 

---

## 🔍 Changes Made
<!-- List key changes in bullet points. -->
- Update the `build-and-push-images.yml` file to check the changes and push the updated image to GHCR.
- Use the published image in the docker compose.
---

## ✅ Checklist (Email System)
- [x] Core services tested (SMTP, IMAP, mail storage, end-to-end delivery)
- [x] Security & compliance verified (auth via Thunder IDP, TLS, DKIM/SPF/DMARC, spam/virus filtering)
- [x] Configuration & deployment checked (configs generated, Docker/Compose updated)
- [x] Reliability confirmed (error handling, logging, monitoring)
- [x] Documentation & usage notes updated (README, deployment, API)

---

## 🧪 Testing Instructions
<!-- Explain how reviewers can test your changes. -->

---

## 📷 Screenshots / Logs (if applicable)
<!-- Add screenshots of client tests, log snippets, etc. -->

---

## ⚠️ Notes for Reviewers
<!-- Add special notes for reviewers (e.g., schema changes, ports affected, config updates). -->