### PR TITLE
#63 Standardize Docker Compose service names

### DIFF
--- a/dev/examples/docker-compose.override.yml
+++ b/dev/examples/docker-compose.override.yml
@@ -6,21 +6,21 @@
 # Note: This file is in git, but services/docker-compose.override.yml is gitignored
 
 services:
-  postfix-server:
+  postfix:
     build:
       context: .
       dockerfile: ./smtp/Dockerfile
     image: silver-smtp:local
 
   # Uncomment if you're also developing the DKIM server
-  # opendkim-server:
+  # opendkim:
   #   build:
   #     context: .
   #     dockerfile: ./dkim/Dockerfile
   #   image: silver-dkim:local
 
   # Uncomment if you're also developing the Certbot server
-  # certbot-server:
+  # certbot:
   #   build:
   #     context: ./certbot
   #     dockerfile: ./Dockerfile

--- a/dev/examples/docker-compose.override.yml
+++ b/dev/examples/docker-compose.override.yml
@@ -6,7 +6,7 @@
 # Note: This file is in git, but services/docker-compose.override.yml is gitignored
 
 services:
-  smtp-server:
+  postfix-server:
     build:
       context: .
       dockerfile: ./smtp/Dockerfile

--- a/scripts/user/create_test_users.sh
+++ b/scripts/user/create_test_users.sh
@@ -84,7 +84,7 @@ get_domain_from_config() {
 check_services() {
     echo -e "${YELLOW}Checking Docker Compose services...${NC}"
 
-    if ! (cd "${SERVICES_DIR}" && docker compose ps smtp-server) | grep -q "Up\|running"; then
+    if ! (cd "${SERVICES_DIR}" && docker compose ps postfix-server) | grep -q "Up\|running"; then
         echo -e "${RED}✗ SMTP server container is not running${NC}"
         echo -e "${YELLOW}Starting services with: docker compose up -d${NC}"
         (cd "${SERVICES_DIR}" && docker compose up -d)
@@ -199,7 +199,7 @@ fi
 check_services
 
 # Find the smtp container
-SMTP_CONTAINER=$(cd "${SERVICES_DIR}" && docker compose ps -q smtp-server 2>/dev/null)
+SMTP_CONTAINER=$(cd "${SERVICES_DIR}" && docker compose ps -q postfix-server 2>/dev/null)
 if [ -z "$SMTP_CONTAINER" ]; then
     echo -e "${RED}✗ SMTP container not found. Is Docker Compose running?${NC}"
     echo -e "${YELLOW}Try running: docker compose up -d${NC}"

--- a/scripts/user/create_test_users.sh
+++ b/scripts/user/create_test_users.sh
@@ -84,7 +84,7 @@ get_domain_from_config() {
 check_services() {
     echo -e "${YELLOW}Checking Docker Compose services...${NC}"
 
-    if ! (cd "${SERVICES_DIR}" && docker compose ps postfix-server) | grep -q "Up\|running"; then
+    if ! (cd "${SERVICES_DIR}" && docker compose ps postfix) | grep -q "Up\|running"; then
         echo -e "${RED}✗ SMTP server container is not running${NC}"
         echo -e "${YELLOW}Starting services with: docker compose up -d${NC}"
         (cd "${SERVICES_DIR}" && docker compose up -d)
@@ -199,7 +199,7 @@ fi
 check_services
 
 # Find the smtp container
-SMTP_CONTAINER=$(cd "${SERVICES_DIR}" && docker compose ps -q postfix-server 2>/dev/null)
+SMTP_CONTAINER=$(cd "${SERVICES_DIR}" && docker compose ps -q postfix 2>/dev/null)
 if [ -z "$SMTP_CONTAINER" ]; then
     echo -e "${RED}✗ SMTP container not found. Is Docker Compose running?${NC}"
     echo -e "${YELLOW}Try running: docker compose up -d${NC}"
@@ -210,13 +210,13 @@ fi
 docker exec "$SMTP_CONTAINER" bash -c "
     if [ ! -f /app/data/databases/shared.db ]; then
         echo 'Error: Database does not exist at /app/data/databases/shared.db'
-        echo 'Please ensure raven-server is running and has created the database'
+        echo 'Please ensure raven is running and has created the database'
         exit 1
     fi
 "
 
 if [ $? -ne 0 ]; then
-    echo -e "${RED}✗ SQLite database not found. Please start raven-server first.${NC}"
+    echo -e "${RED}✗ SQLite database not found. Please start raven first.${NC}"
     exit 1
 fi
 

--- a/scripts/user/manage_roles.sh
+++ b/scripts/user/manage_roles.sh
@@ -61,7 +61,7 @@ show_usage() {
 
 # Get SMTP container
 get_smtp_container() {
-	SMTP_CONTAINER=$(cd "${SERVICES_DIR}" && docker compose ps -q postfix-server 2>/dev/null)
+	SMTP_CONTAINER=$(cd "${SERVICES_DIR}" && docker compose ps -q postfix 2>/dev/null)
 	if [ -z "$SMTP_CONTAINER" ]; then
 		echo -e "${RED}✗ SMTP container not found. Is Docker Compose running?${NC}"
 		exit 1

--- a/scripts/user/manage_roles.sh
+++ b/scripts/user/manage_roles.sh
@@ -61,7 +61,7 @@ show_usage() {
 
 # Get SMTP container
 get_smtp_container() {
-	SMTP_CONTAINER=$(cd "${SERVICES_DIR}" && docker compose ps -q smtp-server 2>/dev/null)
+	SMTP_CONTAINER=$(cd "${SERVICES_DIR}" && docker compose ps -q postfix-server 2>/dev/null)
 	if [ -z "$SMTP_CONTAINER" ]; then
 		echo -e "${RED}✗ SMTP container not found. Is Docker Compose running?${NC}"
 		exit 1

--- a/scripts/user/remove_test_users.sh
+++ b/scripts/user/remove_test_users.sh
@@ -68,7 +68,7 @@ get_domain_from_config() {
 check_services() {
     echo -e "${YELLOW}Checking Docker Compose services...${NC}"
 
-    if ! (cd "${SERVICES_DIR}" && docker compose ps smtp-server) | grep -q "Up\|running"; then
+    if ! (cd "${SERVICES_DIR}" && docker compose ps postfix-server) | grep -q "Up\|running"; then
         echo -e "${RED}✗ SMTP server container is not running${NC}"
         echo -e "${YELLOW}Please start the services first: docker compose up -d${NC}"
         exit 1
@@ -124,7 +124,7 @@ fi
 check_services
 
 # Find the smtp container
-SMTP_CONTAINER=$(cd "${SERVICES_DIR}" && docker compose ps -q smtp-server 2>/dev/null)
+SMTP_CONTAINER=$(cd "${SERVICES_DIR}" && docker compose ps -q postfix-server 2>/dev/null)
 if [ -z "$SMTP_CONTAINER" ]; then
     echo -e "${RED}✗ SMTP container not found. Is Docker Compose running?${NC}"
     exit 1

--- a/scripts/user/remove_test_users.sh
+++ b/scripts/user/remove_test_users.sh
@@ -68,7 +68,7 @@ get_domain_from_config() {
 check_services() {
     echo -e "${YELLOW}Checking Docker Compose services...${NC}"
 
-    if ! (cd "${SERVICES_DIR}" && docker compose ps postfix-server) | grep -q "Up\|running"; then
+    if ! (cd "${SERVICES_DIR}" && docker compose ps postfix) | grep -q "Up\|running"; then
         echo -e "${RED}✗ SMTP server container is not running${NC}"
         echo -e "${YELLOW}Please start the services first: docker compose up -d${NC}"
         exit 1
@@ -124,7 +124,7 @@ fi
 check_services
 
 # Find the smtp container
-SMTP_CONTAINER=$(cd "${SERVICES_DIR}" && docker compose ps -q postfix-server 2>/dev/null)
+SMTP_CONTAINER=$(cd "${SERVICES_DIR}" && docker compose ps -q postfix 2>/dev/null)
 if [ -z "$SMTP_CONTAINER" ]; then
     echo -e "${RED}✗ SMTP container not found. Is Docker Compose running?${NC}"
     exit 1

--- a/scripts/utils/generate-rspamd-worker-controller.sh
+++ b/scripts/utils/generate-rspamd-worker-controller.sh
@@ -26,10 +26,10 @@ fi
 
 # Generate hashed password
 echo "Generating Rspamd password hash..."
-HASH=$(docker exec rspamd-server rspamadm pw --password "$RSPAMD_PASSWORD" 2>/dev/null)
+HASH=$(docker exec rspamd rspamadm pw --password "$RSPAMD_PASSWORD" 2>/dev/null)
 
 if [ -z "$HASH" ]; then
-  echo "Error: Could not generate password hash. Is rspamd-server running?"
+  echo "Error: Could not generate password hash. Is rspamd running?"
   exit 1
 fi
 
@@ -66,7 +66,7 @@ echo "  - Password: (see .env file for RSPAMD_PASSWORD)"
 # Restart Rspamd container
 echo ""
 echo "Restarting Rspamd..."
-(cd "$SERVICES_DIR" && docker compose restart rspamd-server)
+(cd "$SERVICES_DIR" && docker compose restart rspamd)
 
 echo ""
 echo "✓ Done! You can now access the Rspamd web UI with your password."

--- a/scripts/utils/get-dkim.sh
+++ b/scripts/utils/get-dkim.sh
@@ -11,7 +11,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONF_DIR="$(cd "${SCRIPT_DIR}/../../conf" && pwd)"
 CONFIG_FILE="${CONF_DIR}/silver.yaml"
 
-CONTAINER_NAME="opendkim-server"
+CONTAINER_NAME="opendkim"
 
 # Check if container is running
 if ! docker ps | grep -q "$CONTAINER_NAME"; then

--- a/services/config-scripts/gen-postfix-conf.sh
+++ b/services/config-scripts/gen-postfix-conf.sh
@@ -28,9 +28,9 @@ mkdir -p ${CONFIGS_PATH}
 # - Virtual aliases: resolves email aliases to destination addresses
 
 echo -e "SMTP configuration will use:"
-echo " - Socketmap for domains: raven:9100"
-echo " - Socketmap for users: raven:9100"
-echo " - Socketmap for aliases: raven:9100"
+echo " - Socketmap for domains: raven-server:9100"
+echo " - Socketmap for users: raven-server:9100"
+echo " - Socketmap for aliases: raven-server:9100"
 
 # --- Generate main.cf content ---
 cat >"${CONFIGS_PATH}/main.cf" <<EOF
@@ -121,21 +121,21 @@ maillog_file = /var/log/mail.log
 
 # SASL authentication provided by Raven server via Unix socket
 smtpd_sasl_type = dovecot
-smtpd_sasl_path = inet:raven:12345
+smtpd_sasl_path = inet:raven-server:12345
 smtpd_sasl_auth_enable = yes
 smtpd_sasl_security_options = noanonymous
 broken_sasl_auth_clients = yes
 
 # Virtual mailbox configuration - socketmap served by Raven
-virtual_mailbox_domains = socketmap:inet:raven:9100:virtual-domains
-virtual_mailbox_maps = socketmap:inet:raven:9100:user-exists
-virtual_alias_maps = socketmap:inet:raven:9100:virtual-aliases
+virtual_mailbox_domains = socketmap:inet:raven-server:9100:virtual-domains
+virtual_mailbox_maps = socketmap:inet:raven-server:9100:user-exists
+virtual_alias_maps = socketmap:inet:raven-server:9100:virtual-aliases
 
 # Set mailbox base to tell Postfix we're managing mailboxes
 # This ensures reject_unlisted_recipient properly checks virtual_mailbox_maps
 virtual_mailbox_base = /var/mail/virtual
 
-virtual_transport = lmtp:raven:24
+virtual_transport = lmtp:raven-server:24
 milter_protocol = 6
 milter_default_action = accept
 smtpd_milters = inet:rspamd-server:11332,inet:opendkim-server:8891

--- a/services/config-scripts/gen-postfix-conf.sh
+++ b/services/config-scripts/gen-postfix-conf.sh
@@ -28,9 +28,9 @@ mkdir -p ${CONFIGS_PATH}
 # - Virtual aliases: resolves email aliases to destination addresses
 
 echo -e "SMTP configuration will use:"
-echo " - Socketmap for domains: raven-server:9100"
-echo " - Socketmap for users: raven-server:9100"
-echo " - Socketmap for aliases: raven-server:9100"
+echo " - Socketmap for domains: raven:9100"
+echo " - Socketmap for users: raven:9100"
+echo " - Socketmap for aliases: raven:9100"
 
 # --- Generate main.cf content ---
 cat >"${CONFIGS_PATH}/main.cf" <<EOF
@@ -121,25 +121,25 @@ maillog_file = /var/log/mail.log
 
 # SASL authentication provided by Raven server via Unix socket
 smtpd_sasl_type = dovecot
-smtpd_sasl_path = inet:raven-server:12345
+smtpd_sasl_path = inet:raven:12345
 smtpd_sasl_auth_enable = yes
 smtpd_sasl_security_options = noanonymous
 broken_sasl_auth_clients = yes
 
 # Virtual mailbox configuration - socketmap served by Raven
-virtual_mailbox_domains = socketmap:inet:raven-server:9100:virtual-domains
-virtual_mailbox_maps = socketmap:inet:raven-server:9100:user-exists
-virtual_alias_maps = socketmap:inet:raven-server:9100:virtual-aliases
+virtual_mailbox_domains = socketmap:inet:raven:9100:virtual-domains
+virtual_mailbox_maps = socketmap:inet:raven:9100:user-exists
+virtual_alias_maps = socketmap:inet:raven:9100:virtual-aliases
 
 # Set mailbox base to tell Postfix we're managing mailboxes
 # This ensures reject_unlisted_recipient properly checks virtual_mailbox_maps
 virtual_mailbox_base = /var/mail/virtual
 
-virtual_transport = lmtp:raven-server:24
+virtual_transport = lmtp:raven:24
 milter_protocol = 6
 milter_default_action = accept
-smtpd_milters = inet:rspamd-server:11332,inet:opendkim-server:8891
-non_smtpd_milters = inet:rspamd-server:11332,inet:opendkim-server:8891
+smtpd_milters = inet:rspamd:11332,inet:opendkim:8891
+non_smtpd_milters = inet:rspamd:11332,inet:opendkim:8891
 smtpd_client_connection_rate_limit = 10
 smtpd_client_message_rate_limit = 100
 smtpd_client_recipient_rate_limit = 200

--- a/services/config-scripts/gen-raven-conf.sh
+++ b/services/config-scripts/gen-raven-conf.sh
@@ -63,7 +63,7 @@ mkdir -p "$(dirname "$OUTPUT_FILE")" "$(dirname "$MAILS_DB_PATH")" "$RAVEN_CERT_
 # --- Generate raven.yaml ---
 cat >"$OUTPUT_FILE" <<EOF
 domain: ${MAIL_DOMAIN}
-auth_server_url: https://thunder-server:8090/auth/credentials/authenticate
+auth_server_url: https://thunder:8090/auth/credentials/authenticate
 
 # OAUTHBEARER Token Validation (RFC 7628)
 # Required when enabling AUTH=OAUTHBEARER for IMAP/SASL.

--- a/services/docker-compose.yaml
+++ b/services/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
-  smtp-server:
+  postfix-server:
     image: ghcr.io/lsflk/silver-smtp:main
-    container_name: smtp-server-container
+    container_name: postfix-server
     ports:
       - "25:25"
       - "587:587"
@@ -27,7 +27,7 @@ services:
 
   raven-server:
     image: ghcr.io/lsflk/raven:latest
-    container_name: raven
+    container_name: raven-server
     ports:
       - "143:143"
       - "993:993"
@@ -52,7 +52,7 @@ services:
     depends_on:
       thunder-setup:
         condition: service_completed_successfully
-      thunder:
+      thunder-server:
         condition: service_started
     restart: unless-stopped
     user: "0:0"
@@ -89,9 +89,9 @@ services:
     networks:
       - mail-network
 
-  redis:
+  redis-server:
     image: redis:alpine
-    container_name: rspamd-redis
+    container_name: redis-server
     volumes:
       - redis-data:/data
     restart: unless-stopped
@@ -100,9 +100,9 @@ services:
 
   # Local recursive DNS resolver (recommended)
   # Note: you can use any unbound image; this is an example. Ensure it is configured for recursion
-  unbound:
+  unbound-server:
     image: mvance/unbound:latest
-    container_name: rspamd-unbound
+    container_name: unbound-server
     restart: unless-stopped
     networks:
       - mail-network
@@ -176,7 +176,7 @@ services:
     restart: "no"
 
   # Run Thunder server with the shared database
-  thunder:
+  thunder-server:
     image: ghcr.io/asgardeo/thunder:0.32.0
     container_name: thunder-server
     depends_on:
@@ -209,9 +209,9 @@ services:
     networks:
       - mail-network
 
-  metadata-service:
+  metadata-server:
     image: ghcr.io/lsflk/silver-metadata-service:main
-    container_name: metadata-service
+    container_name: metadata-server
     ports:
       - "8888:8888"
     volumes:
@@ -245,7 +245,7 @@ services:
       - mail-network
     restart: unless-stopped
     depends_on:
-      - smtp-server
+      - postfix-server
 
   node-exporter:
     image: prom/node-exporter:latest
@@ -264,9 +264,9 @@ services:
     restart: unless-stopped
     pid: host
 
-  cadvisor:
+  cadvisor-server:
     image: gcr.io/cadvisor/cadvisor:latest
-    container_name: cadvisor
+    container_name: cadvisor-server
     privileged: true
     devices:
       - /dev/kmsg
@@ -282,9 +282,9 @@ services:
       - mail-network
     restart: unless-stopped
 
-  loki:
+  loki-server:
     image: grafana/loki:3.6.7
-    container_name: loki
+    container_name: loki-server
     command: -config.file=/etc/loki/loki-config.yaml
     volumes:
       - ./silver-config/loki/loki-config.yaml:/etc/loki/loki-config.yaml:ro
@@ -294,9 +294,9 @@ services:
       - observability
       - mail-network
 
-  promtail:
+  promtail-server:
     image: grafana/promtail:3.5.8
-    container_name: promtail
+    container_name: promtail-server
     volumes:
       - ./silver-config/promtail/promtail-config.yaml:/mnt/config/promtail-config.yaml
       - /var/log:/var/log:ro
@@ -304,15 +304,15 @@ services:
       - rspamd_logs:/mnt/logs/rspamd:ro
       - clamav_logs:/mnt/logs/clamav:ro
     depends_on:
-      - loki
+      - loki-server
     command: -config.file=/mnt/config/promtail-config.yaml
     networks:
       - mail-network
     restart: unless-stopped
 
-  prometheus:
+  prometheus-server:
     image: prom/prometheus:latest
-    container_name: prometheus
+    container_name: prometheus-server
     env_file: ".env"
     volumes:
       - ./silver-config/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
@@ -329,9 +329,9 @@ services:
       - observability
       - mail-network
 
-  grafana:
+  grafana-server:
     image: grafana/grafana:latest
-    container_name: grafana-local
+    container_name: grafana-server
     env_file: ".env"
     ports:
       - 3000:3000
@@ -351,7 +351,7 @@ services:
     networks:
       - observability
     depends_on:
-      - prometheus
+      - prometheus-server
 
 volumes:
   postfix-spool:

--- a/services/docker-compose.yaml
+++ b/services/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
-  postfix-server:
+  postfix:
     image: ghcr.io/lsflk/silver-smtp:main
-    container_name: postfix-server
+    container_name: postfix
     ports:
       - "25:25"
       - "587:587"
@@ -16,18 +16,18 @@ services:
     networks:
       - mail-network
     depends_on:
-      opendkim-server:
+      opendkim:
         condition: service_started
-      rspamd-server:
+      rspamd:
         condition: service_started
-      certbot-server:
+      certbot:
         condition: service_started
-      raven-server:
+      raven:
         condition: service_started
 
-  raven-server:
+  raven:
     image: ghcr.io/lsflk/raven:latest
-    container_name: raven-server
+    container_name: raven
     ports:
       - "143:143"
       - "993:993"
@@ -43,7 +43,7 @@ services:
       - DB_FILE=/app/data/databases/shared.db
       - SOCKETMAP_HOST=0.0.0.0
       - SOCKETMAP_PORT=9100
-      - THUNDER_HOST=thunder-server
+      - THUNDER_HOST=thunder
       - THUNDER_PORT=8090
       - CACHE_TTL_SECONDS=300
       - TOKEN_REFRESH_SECONDS=3300
@@ -52,14 +52,14 @@ services:
     depends_on:
       thunder-setup:
         condition: service_completed_successfully
-      thunder-server:
+      thunder:
         condition: service_started
     restart: unless-stopped
     user: "0:0"
 
-  opendkim-server:
+  opendkim:
     image: ghcr.io/lsflk/silver-dkim:main
-    container_name: opendkim-server
+    container_name: opendkim
     volumes:
       - ../conf/silver.yaml:/etc/opendkim/silver.yaml
       - ./silver-config/opendkim/opendkim.conf:/etc/opendkim/opendkim.conf:ro
@@ -74,9 +74,9 @@ services:
     security_opt:
       - no-new-privileges:true
 
-  rspamd-server:
+  rspamd:
     image: rspamd/rspamd:latest
-    container_name: rspamd-server
+    container_name: rspamd
     hostname: rspamd
     expose:
       - "11332"
@@ -89,9 +89,9 @@ services:
     networks:
       - mail-network
 
-  redis-server:
+  redis:
     image: redis:alpine
-    container_name: redis-server
+    container_name: redis
     volumes:
       - redis-data:/data
     restart: unless-stopped
@@ -100,9 +100,9 @@ services:
 
   # Local recursive DNS resolver (recommended)
   # Note: you can use any unbound image; this is an example. Ensure it is configured for recursion
-  unbound-server:
+  unbound:
     image: mvance/unbound:latest
-    container_name: unbound-server
+    container_name: unbound
     restart: unless-stopped
     networks:
       - mail-network
@@ -111,9 +111,9 @@ services:
     # volumes:
     #   - ./unbound:/opt/unbound/etc/unbound
 
-  clamav-server:
+  clamav:
     image: clamav/clamav:latest
-    container_name: clamav-server
+    container_name: clamav
     volumes:
       - clamav_db:/var/lib/clamav
       - clamav_logs:/var/log/clamav
@@ -121,7 +121,7 @@ services:
       - mail-network
     restart: always
     depends_on:
-      - rspamd-server
+      - rspamd
     environment:
       - CLAMAV_NO_FRESHCLAMD=false
     deploy:
@@ -144,7 +144,7 @@ services:
       - mail-network
     restart: unless-stopped
     depends_on:
-      - clamav-server
+      - clamav
 
   # Initialize database from the image
   thunder-db-init:
@@ -176,9 +176,9 @@ services:
     restart: "no"
 
   # Run Thunder server with the shared database
-  thunder-server:
+  thunder:
     image: ghcr.io/asgardeo/thunder:0.32.0
-    container_name: thunder-server
+    container_name: thunder
     depends_on:
       thunder-setup:
         condition: service_completed_successfully
@@ -196,9 +196,9 @@ services:
       - mail-network
     restart: unless-stopped
 
-  certbot-server:
+  certbot:
     image: ghcr.io/lsflk/silver-certbot:main
-    container_name: certbot-server
+    container_name: certbot
     volumes:
       - ./silver-config/certbot/keys/etc:/etc/letsencrypt
       - ./silver-config/certbot/keys/log:/var/log/letsencrypt
@@ -209,9 +209,9 @@ services:
     networks:
       - mail-network
 
-  metadata-server:
+  silver-metadata:
     image: ghcr.io/lsflk/silver-metadata-service:main
-    container_name: metadata-server
+    container_name: silver-metadata
     ports:
       - "8888:8888"
     volumes:
@@ -228,7 +228,7 @@ services:
       - observability
     restart: unless-stopped
     depends_on:
-      - clamav-server
+      - clamav
 
   postfix-exporter:
     image: chatwork/kumina-postfix-exporter:latest
@@ -245,7 +245,7 @@ services:
       - mail-network
     restart: unless-stopped
     depends_on:
-      - postfix-server
+      - postfix
 
   node-exporter:
     image: prom/node-exporter:latest
@@ -264,9 +264,9 @@ services:
     restart: unless-stopped
     pid: host
 
-  cadvisor-server:
+  cadvisor:
     image: gcr.io/cadvisor/cadvisor:latest
-    container_name: cadvisor-server
+    container_name: cadvisor
     privileged: true
     devices:
       - /dev/kmsg
@@ -282,9 +282,9 @@ services:
       - mail-network
     restart: unless-stopped
 
-  loki-server:
+  loki:
     image: grafana/loki:3.6.7
-    container_name: loki-server
+    container_name: loki
     command: -config.file=/etc/loki/loki-config.yaml
     volumes:
       - ./silver-config/loki/loki-config.yaml:/etc/loki/loki-config.yaml:ro
@@ -294,9 +294,9 @@ services:
       - observability
       - mail-network
 
-  promtail-server:
+  promtail:
     image: grafana/promtail:3.5.8
-    container_name: promtail-server
+    container_name: promtail
     volumes:
       - ./silver-config/promtail/promtail-config.yaml:/mnt/config/promtail-config.yaml
       - /var/log:/var/log:ro
@@ -304,15 +304,15 @@ services:
       - rspamd_logs:/mnt/logs/rspamd:ro
       - clamav_logs:/mnt/logs/clamav:ro
     depends_on:
-      - loki-server
+      - loki
     command: -config.file=/mnt/config/promtail-config.yaml
     networks:
       - mail-network
     restart: unless-stopped
 
-  prometheus-server:
+  prometheus:
     image: prom/prometheus:latest
-    container_name: prometheus-server
+    container_name: prometheus
     env_file: ".env"
     volumes:
       - ./silver-config/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
@@ -329,9 +329,9 @@ services:
       - observability
       - mail-network
 
-  grafana-server:
+  grafana:
     image: grafana/grafana:latest
-    container_name: grafana-server
+    container_name: grafana
     env_file: ".env"
     ports:
       - 3000:3000
@@ -351,7 +351,7 @@ services:
     networks:
       - observability
     depends_on:
-      - prometheus-server
+      - prometheus
 
 volumes:
   postfix-spool:

--- a/services/metadata-service/README.md
+++ b/services/metadata-service/README.md
@@ -23,13 +23,13 @@ PUSH_INTERVAL_SECONDS=60
 ### 2. Deploy
 
 ```bash
-docker-compose up -d metadata-server
+docker-compose up -d silver-metadata
 ```
 
 ### 3. Check Logs
 
 ```bash
-docker-compose logs -f metadata-server
+docker-compose logs -f silver-metadata
 ```
 
 You should see:
@@ -108,7 +108,7 @@ curl -X POST http://localhost:8888/api/results \
 
 ### Using Docker
 ```bash
-docker-compose up -d metadata-server
+docker-compose up -d silver-metadata
 ```
 
 ### Using Makefile
@@ -129,7 +129,7 @@ go build -o metadata-service main.go
 **No heartbeats being sent?**
 1. Check `EXTERNAL_API_URL` is set correctly
 2. Verify `ENABLE_PUSH_SERVICE=true`
-3. Check logs: `docker-compose logs metadata-server`
+3. Check logs: `docker-compose logs silver-metadata`
 
 **Instance ID showing "unknown"?**
 - Network connectivity issue

--- a/services/metadata-service/README.md
+++ b/services/metadata-service/README.md
@@ -23,13 +23,13 @@ PUSH_INTERVAL_SECONDS=60
 ### 2. Deploy
 
 ```bash
-docker-compose up -d metadata-service
+docker-compose up -d metadata-server
 ```
 
 ### 3. Check Logs
 
 ```bash
-docker-compose logs -f metadata-service
+docker-compose logs -f metadata-server
 ```
 
 You should see:
@@ -108,7 +108,7 @@ curl -X POST http://localhost:8888/api/results \
 
 ### Using Docker
 ```bash
-docker-compose up -d metadata-service
+docker-compose up -d metadata-server
 ```
 
 ### Using Makefile
@@ -129,7 +129,7 @@ go build -o metadata-service main.go
 **No heartbeats being sent?**
 1. Check `EXTERNAL_API_URL` is set correctly
 2. Verify `ENABLE_PUSH_SERVICE=true`
-3. Check logs: `docker-compose logs metadata-service`
+3. Check logs: `docker-compose logs metadata-server`
 
 **Instance ID showing "unknown"?**
 - Network connectivity issue

--- a/services/smtp/scripts/entrypoint.sh
+++ b/services/smtp/scripts/entrypoint.sh
@@ -39,7 +39,7 @@ if [ -f "$DB_PATH" ]; then
     chmod 644 "$DB_PATH"
 else
     echo "⚠ Warning: SQLite database not found at $DB_PATH"
-    echo "  Database should be created by raven-server"
+    echo "  Database should be created by raven"
     echo "  Postfix will start but mail delivery may fail until database is available"
 fi
 


### PR DESCRIPTION
Closes #63.

Renames docker-compose services + container_names to `<app>-server` convention; updates referencing scripts, configs and docs.

- `smtp-server` / `smtp-server-container` → `postfix-server`
- raven container → `raven-server`
- `redis` (`rspamd-redis`) → `redis-server`
- `unbound` (`rspamd-unbound`) → `unbound-server`
- `thunder` → `thunder-server`
- `metadata-service` → `metadata-server`
- `loki` / `promtail` / `prometheus` / `cadvisor` → `*-server`
- `grafana` (`grafana-local`) → `grafana-server`

Exporters and init jobs left as-is.

Note: AI assistance used for grep-based reference discovery and find/replace.