### PR TITLE
feat(charts): add Thunder identity server via umbrella dependency

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -138,3 +138,63 @@ If not ready yet, check progress:
 kubectl describe certificate <name> -n silver
 ```
 ---
+
+## Thunder identity server
+
+Thunder is pulled in as an upstream OCI dependency
+(`oci://ghcr.io/asgardeo/helm-charts/thunder`, version `0.32.0`) and configured
+under the `thunder:` key in the umbrella values. The defaults in
+[silver/values.yaml](silver/values.yaml) reproduce the docker-compose `thunder`
+setup: the `0.32.0` image, a shared SQLite database seeded from the image (via an
+init container, replacing the compose `thunder-db-init`), a one-time setup job
+(compose `thunder-setup`), a single pod, and the bootstrap scripts from
+[scripts/thunder](../scripts/thunder).
+
+### Bootstrap ConfigMap (required before install)
+
+Thunder's setup job runs as a Helm **pre-install hook**, so the bootstrap
+ConfigMap it references must already exist in the namespace. Create it from the
+canonical scripts (they are not duplicated into the chart):
+
+```bash
+scripts/thunder/create-bootstrap-configmap.sh silver          # <namespace> [configmap-name]
+```
+
+This mounts `01-default-resources.sh` and `02-sample-resources.sh` via `subPath`,
+preserving the image's default bootstrap scripts (including `common.sh`, which
+`01`/`02` source). Re-run it to push script changes; it is idempotent.
+
+### Admin credentials (Secret, required before install)
+
+The admin **username** is `admin` (in `thunder.setup.env`). The **password** is
+not stored in values — it is read from a Secret via `thunder.setup.secretEnv`.
+Create it in the release namespace before installing:
+
+```bash
+kubectl create secret generic thunder-admin-credentials \
+  --namespace silver \
+  --from-literal=password='<your-password>'
+```
+
+### Install
+
+```bash
+# 1. Bootstrap ConfigMap + admin Secret first (pre-install hook dependencies)
+scripts/thunder/create-bootstrap-configmap.sh silver
+kubectl create secret generic thunder-admin-credentials \
+  --namespace silver --from-literal=password='<your-password>'
+
+# 2. Install the umbrella (Thunder enabled by default)
+helm dependency update ./charts/silver
+helm upgrade --install silver ./charts/silver \
+  --set global.domain=yourdomain.com \
+  --namespace silver --create-namespace
+```
+
+Thunder is reached in-cluster on its Service at port `8090` (e.g. raven ->
+`thunder:8090`), matching the compose network. External ingress is disabled by
+default; enable `thunder.ingress` and point it at your domain if you need the
+console/gate UIs exposed. The dev overlay
+([values-dev.yaml](silver/values-dev.yaml)) disables Thunder for a postfix-only
+bring-up.
+---

--- a/charts/silver/Chart.lock
+++ b/charts/silver/Chart.lock
@@ -5,5 +5,17 @@ dependencies:
 - name: postfix
   repository: file://charts/postfix
   version: 0.1.0
-digest: sha256:59b26a4b4d95e319491a2e68773598b844195a42f1c6e17677a55593d5261ade
-generated: "2026-05-17T22:57:17.033738+05:30"
+- name: redis
+  repository: file://charts/redis
+  version: 0.1.0
+- name: unbound
+  repository: file://charts/unbound
+  version: 0.1.0
+- name: rspamd
+  repository: file://charts/rspamd
+  version: 0.1.0
+- name: thunder
+  repository: oci://ghcr.io/asgardeo/helm-charts
+  version: 0.32.0
+digest: sha256:c2d4f08ddd201dba1702fdd4288914d3ccd61a1879dd5b2ff3a6c268746f9aa0
+generated: "2026-07-16T15:04:05.686793+05:30"

--- a/charts/silver/Chart.yaml
+++ b/charts/silver/Chart.yaml
@@ -26,3 +26,9 @@ dependencies:
     version: 0.1.0
     repository: file://charts/rspamd
     condition: rspamd.enabled
+  # Thunder identity server (upstream OCI chart). Mirrors the docker-compose
+  # `thunder`/`thunder-setup`/`thunder-db-init` services.
+  - name: thunder
+    version: 0.32.0
+    repository: oci://ghcr.io/asgardeo/helm-charts
+    condition: thunder.enabled

--- a/charts/silver/values-dev.yaml
+++ b/charts/silver/values-dev.yaml
@@ -20,3 +20,6 @@ postfix:
 # the pod still starts.
 opendkim:
   enabled: false
+
+thunder:
+  enabled: false

--- a/charts/silver/values-local.yaml
+++ b/charts/silver/values-local.yaml
@@ -1,0 +1,44 @@
+# Local minikube bring-up for Thunder only, reachable via
+#   kubectl port-forward svc/silver-thunder-service 8090:8090
+# and a browser at https://localhost:8090/console.
+#
+# No cert-manager, no mail services. TLS off so the umbrella skips Certificate
+# objects; Thunder still serves HTTPS on 8090 with its bundled self-signed cert.
+global:
+  domain: localhost
+  tls:
+    enabled: false
+
+opendkim:
+  enabled: false
+postfix:
+  enabled: false
+
+thunder:
+  enabled: true
+  configuration:
+    server:
+      # Drives the base URL the console/gate SPAs call from the browser.
+      publicUrl: "https://localhost:8090"
+    gateClient:
+      hostname: "localhost"
+      port: 8090
+      scheme: "https"
+  setup:
+    env:
+      - name: THUNDER_ADMIN_USERNAME
+        value: "admin"
+      # Must match server.publicUrl — the bootstrap script registers the CONSOLE
+      # app's allowed redirect URI as ${THUNDER_PUBLIC_URL}/console. If this and
+      # publicUrl disagree, OAuth fails with "Invalid redirect URI".
+      - name: THUNDER_PUBLIC_URL
+        value: "https://localhost:8090"
+    # Admin password is sourced from a Secret, not stored in values. Create it
+    # before installing:
+    #   kubectl create secret generic thunder-admin-credentials \
+    #     --namespace silver --from-literal=password='<your-password>'
+    secretEnv:
+      - name: THUNDER_ADMIN_PASSWORD
+        secretName: thunder-admin-credentials
+        secretKey: password
+        optional: false

--- a/charts/silver/values.yaml
+++ b/charts/silver/values.yaml
@@ -83,6 +83,12 @@ thunder:
     size: 1Gi
 
   configuration:
+    # Public URL the console/gate SPAs are served from and call back to.
+    # Required for non-local deployments — set it to your externally reachable
+    # URL and keep setup.env THUNDER_PUBLIC_URL (below) in sync, otherwise the
+    # CONSOLE app's redirect URI won't match and OAuth login fails.
+    # server:
+    #   publicUrl: "https://<your-domain>"
     database:
       config:
         type: "sqlite"
@@ -101,6 +107,12 @@ thunder:
     env:
       - name: THUNDER_ADMIN_USERNAME
         value: "admin"
+      # Must match configuration.server.publicUrl. The bootstrap script registers
+      # the CONSOLE app's redirect URI as ${THUNDER_PUBLIC_URL}/console; if unset
+      # it falls back to an empty value and OAuth login fails with "Invalid
+      # redirect URI". Uncomment and set alongside publicUrl for real deployments.
+      # - name: THUNDER_PUBLIC_URL
+      #   value: "https://<your-domain>"
     # Admin password is sourced from a Secret, not stored in values. Create it in
     # the release namespace before installing:
     #   kubectl create secret generic thunder-admin-credentials \

--- a/charts/silver/values.yaml
+++ b/charts/silver/values.yaml
@@ -39,3 +39,84 @@ unbound:
 
 rspamd:
   enabled: false
+
+# Thunder identity server. Values below reproduce the docker-compose thunder
+# setup (services/docker-compose.yaml): the 0.32.0 image, a shared SQLite
+# database seeded from the image, a one-time setup job, and the bootstrap
+# scripts from scripts/thunder.
+#
+# ⚠️ Before installing with thunder.enabled=true, create the bootstrap ConfigMap
+#    referenced below (it is a hard dependency of the pre-install setup job):
+#      scripts/thunder/create-bootstrap-configmap.sh <namespace>
+thunder:
+  enabled: true
+
+  deployment:
+    # SQLite is single-writer, so run exactly one pod (matches the single
+    # `thunder` container in compose).
+    replicaCount: 1
+    securityContext:
+      # SQLite needs a writable filesystem; the chart requires this to be false
+      # whenever a sqlite database is used.
+      readOnlyRootFilesystem: false
+    image:
+      registry: "ghcr.io/asgardeo"
+      repository: "thunder"
+      tag: "0.32.0"
+
+  # A single SQLite pod cannot be horizontally scaled.
+  hpa:
+    enabled: false
+
+  # In compose, thunder is reached in-cluster on 8090 (raven -> thunder:8090).
+  # The ClusterIP Service covers that path, so no external ingress is created by
+  # default. Enable and point at global.domain if you need the console/gate UIs
+  # exposed.
+  ingress:
+    enabled: false
+
+  # SQLite requires a PVC. An init container seeds it from the image on first
+  # start — this is the Helm equivalent of the compose `thunder-db-init` service
+  # (and the shared thunder-db / consent-db volumes).
+  persistence:
+    enabled: true
+    size: 1Gi
+
+  configuration:
+    database:
+      config:
+        type: "sqlite"
+      runtime:
+        type: "sqlite"
+      user:
+        type: "sqlite"
+    consent:
+      enabled: true
+      database:
+        type: "sqlite"
+
+  # One-time initialization job (compose `thunder-setup` running ./setup.sh).
+  setup:
+    enabled: true
+    env:
+      - name: THUNDER_ADMIN_USERNAME
+        value: "admin"
+    # Admin password is sourced from a Secret, not stored in values. Create it in
+    # the release namespace before installing:
+    #   kubectl create secret generic thunder-admin-credentials \
+    #     --namespace silver --from-literal=password='<your-password>'
+    secretEnv:
+      - name: THUNDER_ADMIN_PASSWORD
+        secretName: thunder-admin-credentials
+        secretKey: password
+        optional: false
+
+  # Bootstrap scripts from scripts/thunder, delivered via an external ConfigMap
+  # (Pattern 2). Listing files mounts only these via subPath, preserving the
+  # image's default bootstrap scripts (e.g. common.sh, which 01/02 source).
+  bootstrap:
+    configMap:
+      name: "thunder-bootstrap"
+      files:
+        - 01-default-resources.sh
+        - 02-sample-resources.sh

--- a/scripts/thunder/create-bootstrap-configmap.sh
+++ b/scripts/thunder/create-bootstrap-configmap.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Create the Thunder bootstrap ConfigMap from the scripts in this directory.
+#
+# The Thunder Helm chart's setup job is a Helm pre-install hook, so the
+# ConfigMap it references (thunder.bootstrap.configMap.name in the silver
+# umbrella values) must already exist in the namespace *before* you run
+# `helm install`. This script creates/refreshes it directly from the canonical
+# scripts here, so they are never duplicated into the chart.
+#
+# Usage:
+#   scripts/thunder/create-bootstrap-configmap.sh [namespace] [configmap-name]
+#
+# Defaults: namespace=silver, configmap-name=thunder-bootstrap
+set -euo pipefail
+
+NAMESPACE="${1:-silver}"
+CONFIGMAP_NAME="${2:-thunder-bootstrap}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+
+# Keep this list in sync with thunder.bootstrap.configMap.files in
+# charts/silver/values.yaml. common.sh is intentionally omitted — it ships with
+# the Thunder image and is preserved because we mount individual files.
+FILES=(
+  "01-default-resources.sh"
+  "02-sample-resources.sh"
+)
+
+FROM_FILE_ARGS=()
+for f in "${FILES[@]}"; do
+  if [[ ! -f "${SCRIPT_DIR}/${f}" ]]; then
+    echo "error: ${SCRIPT_DIR}/${f} not found" >&2
+    exit 1
+  fi
+  FROM_FILE_ARGS+=(--from-file="${f}=${SCRIPT_DIR}/${f}")
+done
+
+kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+
+# --dry-run|apply so the command is idempotent (safe to re-run to update scripts).
+kubectl create configmap "${CONFIGMAP_NAME}" \
+  --namespace "${NAMESPACE}" \
+  "${FROM_FILE_ARGS[@]}" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+echo "ConfigMap '${CONFIGMAP_NAME}' created/updated in namespace '${NAMESPACE}'."

--- a/scripts/thunder/create-bootstrap-configmap.sh
+++ b/scripts/thunder/create-bootstrap-configmap.sh
@@ -34,7 +34,10 @@ for f in "${FILES[@]}"; do
   FROM_FILE_ARGS+=(--from-file="${f}=${SCRIPT_DIR}/${f}")
 done
 
-kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+# Best-effort namespace creation. Ignore failures (already exists, or the caller
+# only has namespace-scoped permissions) — if the namespace is truly missing the
+# ConfigMap creation below fails with a clear error anyway.
+kubectl create namespace "${NAMESPACE}" 2>/dev/null || true
 
 # --dry-run|apply so the command is idempotent (safe to re-run to update scripts).
 kubectl create configmap "${CONFIGMAP_NAME}" \


### PR DESCRIPTION
## Summary

Wires the upstream **Thunder 0.32.0** OCI Helm chart (`oci://ghcr.io/asgardeo/helm-charts/thunder`) into the `silver` umbrella as a dependency, configured to reproduce the docker-compose `thunder` / `thunder-setup` / `thunder-db-init` setup.

## Changes

- **`charts/silver/Chart.yaml`** — add `thunder` 0.32.0 as an OCI dependency, gated on `thunder.enabled`.
- **`charts/silver/values.yaml`** — `thunder:` block mirroring compose:
  - SQLite for config/runtime/user/consent DBs, seeded from the image via the chart's init container (replaces `thunder-db-init`)
  - single pod (SQLite is single-writer), HPA off, writable root FS
  - one-time setup job (`thunder-setup`) with bootstrap scripts from `scripts/thunder` delivered via an external ConfigMap (Pattern 2 — preserves the image's default `common.sh`)
  - ClusterIP-only by default; in-cluster access on `8090` (e.g. `raven -> thunder`)
  - admin password sourced from a Secret (`setup.secretEnv`), **not** stored in values
- **`scripts/thunder/create-bootstrap-configmap.sh`** — idempotent helper that builds the bootstrap ConfigMap from the canonical scripts (a pre-install hook dependency), avoiding duplication into the chart.
- **`charts/silver/values-local.yaml`** — overlay for local minikube browser testing (`publicUrl`/gate client + `THUNDER_PUBLIC_URL` pointed at `localhost:8090`).
- **`charts/silver/values-dev.yaml`** — Thunder disabled for the postfix-only bring-up.
- **`charts/README.md`** — install/operations docs (bootstrap ConfigMap, admin Secret, install flow).

## Install

```bash
scripts/thunder/create-bootstrap-configmap.sh silver
kubectl create secret generic thunder-admin-credentials \
  --namespace silver --from-literal=password='<your-password>'
helm dependency update ./charts/silver
helm upgrade --install silver ./charts/silver \
  --set global.domain=yourdomain.com --namespace silver --create-namespace
```

## Testing

Verified on minikube: `helm dependency update` pulls the chart; `helm template`/`helm lint` pass; the setup job seeds SQLite and runs the bootstrap scripts; the console UI loads and the OAuth login flow completes via `kubectl port-forward svc/silver-thunder-service 8090:8090` at `https://localhost:8090/console`.