### PR TITLE
fix: update references from Silver to OpenGovMail in configuration files

### DIFF
--- a/charts/opengovmail/charts/opendkim/templates/secret-opengovmail.yaml
+++ b/charts/opengovmail/charts/opendkim/templates/secret-opengovmail.yaml
@@ -9,7 +9,7 @@ stringData:
   # Drives key GENERATION. Must list exactly the domains configmap-tables.yaml
   # signs for, so both read the same opendkim.domains helper — otherwise keys get
   # generated for one domain and the SigningTable looks for another.
-  silver.yaml: |
+  opengovmail.yaml: |
     domains:
 {{- range include "opendkim.domains" . | fromJsonArray }}
       - domain: {{ .domain | quote }}

--- a/charts/opengovmail/charts/opendkim/templates/workload.yaml
+++ b/charts/opengovmail/charts/opendkim/templates/workload.yaml
@@ -76,11 +76,11 @@ spec:
             failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
           volumeMounts:
             - name: opengovmail-secret
-              # NOTE: filename must stay "silver.yaml" until the opendkim image is
-              # rebuilt — the current ghcr.io/lsflk/silver-dkim image's entrypoint
+              # NOTE: filename must stay "opengovmail.yaml" until the opendkim image is
+              # rebuilt — the current ghcr.io/opengovmail/opengovmail-dkim image's entrypoint
               # script has this exact path hardcoded.
-              mountPath: /etc/opendkim/silver.yaml
-              subPath: silver.yaml
+              mountPath: /etc/opendkim/opengovmail.yaml
+              subPath: opengovmail.yaml
               readOnly: true
             - name: config
               mountPath: /etc/opendkim/opendkim.conf

--- a/charts/opengovmail/charts/opendkim/values.yaml
+++ b/charts/opengovmail/charts/opendkim/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/lsflk/silver-dkim
+  repository: ghcr.io/opengovmail/opengovmail-dkim
   tag: main
   pullPolicy: IfNotPresent
 

--- a/charts/opengovmail/charts/postfix/templates/configmap-postfix.yaml
+++ b/charts/opengovmail/charts/postfix/templates/configmap-postfix.yaml
@@ -9,6 +9,6 @@ data:
 {{ tpl (.Files.Get "files/postfix/main.cf") . | indent 4 }}
   master.cf: |
 {{ tpl (.Files.Get "files/postfix/master.cf") . | indent 4 }}
-  silver.yaml: |
+  opengovmail.yaml: |
     domains:
       - domain: {{ include "opengovmail.domain" . }}

--- a/charts/opengovmail/charts/postfix/templates/postfix-deployment.yaml
+++ b/charts/opengovmail/charts/postfix/templates/postfix-deployment.yaml
@@ -52,11 +52,11 @@ spec:
               mountPath: /etc/postfix/master.cf
               subPath: master.cf
             - name: postfix-opengovmail
-              # NOTE: filename must stay "silver.yaml" until the postfix image is
-              # rebuilt — the current ghcr.io/lsflk/silver-smtp image's entrypoint
+              # NOTE: filename must stay "opengovmail.yaml" until the postfix image is
+              # rebuilt — the current ghcr.io/opengovmail/opengovmail-smtp image's entrypoint
               # script has this exact path hardcoded.
-              mountPath: /etc/postfix/silver.yaml
-              subPath: silver.yaml
+              mountPath: /etc/postfix/opengovmail.yaml
+              subPath: opengovmail.yaml
             {{- if .Values.global.tls.enabled }}
             - name: tls
               mountPath: /certs
@@ -100,8 +100,8 @@ spec:
           configMap:
             name: {{ include "postfix.fullname" . }}
             items:
-              - key: silver.yaml
-                path: silver.yaml
+              - key: opengovmail.yaml
+                path: opengovmail.yaml
         {{- if .Values.global.tls.enabled }}
         - name: tls
           secret:

--- a/charts/opengovmail/charts/postfix/values.yaml
+++ b/charts/opengovmail/charts/postfix/values.yaml
@@ -3,7 +3,7 @@
 # umbrella's `global` block (global.domain, global.serviceNames, global.tlsSecretName).
 
 image:
-  repository: ghcr.io/lsflk/silver-smtp
+  repository: ghcr.io/opengovmail/opengovmail-smtp
   tag: main
   pullPolicy: Always
 

--- a/charts/opengovmail/charts/raven/Chart.yaml
+++ b/charts/opengovmail/charts/raven/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: raven
-description: Raven IMAP/SASL/LMTP + socketmap server for Silver mail retrieval and delivery
+description: Raven IMAP/SASL/LMTP + socketmap server for OpenGovMail mail retrieval and delivery
 type: application
 version: 0.1.0
 # Tracks ghcr.io/lsflk/raven; compose/manifests use :latest, pin a digest in prod.

--- a/services/docker-compose.yaml
+++ b/services/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   postfix:
-    image: ghcr.io/lsflk/silver-smtp:main
+    image: ghcr.io/opengovmail/opengovmail-smtp:main
     container_name: postfix
     ports:
       - "25:25"
@@ -58,7 +58,7 @@ services:
     user: "0:0"
 
   opendkim:
-    image: ghcr.io/lsflk/silver-dkim:main
+    image: ghcr.io/opengovmail/opengovmail-dkim:main
     container_name: opendkim
     volumes:
       - ../conf/opengovmail.yaml:/etc/opendkim/opengovmail.yaml
@@ -197,7 +197,7 @@ services:
     restart: unless-stopped
 
   certbot:
-    image: ghcr.io/lsflk/silver-certbot:main
+    image: ghcr.io/opengovmail/opengovmail-certbot:main
     container_name: certbot
     volumes:
       - ./opengovmail-config/certbot/keys/etc:/etc/letsencrypt
@@ -210,7 +210,7 @@ services:
       - mail-network
 
   opengovmail-metadata:
-    image: ghcr.io/lsflk/silver-metadata-service:main
+    image: ghcr.io/opengovmail/opengovmail-metadata-service:main
     container_name: opengovmail-metadata
     ports:
       - "8888:8888"


### PR DESCRIPTION
## 📌 Description
Fixes leftover Silver naming references in config/chart/compose files to OpenGovMail.

- Closes #350



## 🔍 Changes Made
- Renamed Silver references to OpenGovMail in OpenDKIM/Postfix/Raven/Compose configs.
- Scope is naming consistency only (no intended behavior change).



## ✅ Checklist (Email System)
- [x] Configuration & deployment checked (configs generated, Docker/Compose updated)



## 🧪 Testing Instructions
1. Start the stack from this branch.
2. Verify services boot without old-reference errors.
3. Send one test email and confirm delivery.



## ⚠️ Notes for Reviewers
Small, targeted rename cleanup to align naming across the stack.